### PR TITLE
fix image versions and use node version 20

### DIFF
--- a/diplomarbeit/Dockerfile
+++ b/diplomarbeit/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7-labs
 
-FROM node:lts as build-stage
+FROM node:20-slim@sha256:ec35a66c9a0a275b027debde05247c081f8b2f0c43d7399d3a6ad5660cee2f6a as build-stage
 WORKDIR /app
 
 COPY package*.json ./

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS build-stage
+FROM node:20-slim@sha256:ec35a66c9a0a275b027debde05247c081f8b2f0c43d7399d3a6ad5660cee2f6a AS build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -7,7 +7,7 @@ ARG SCRUMPLICITY_LARAVEL_API_URL
 ENV SCRUMPLICITY_LARAVEL_API_URL=${SCRUMPLICITY_LARAVEL_API_URL}
 RUN npm run build
 
-FROM node:lts-alpine AS production-stage
+FROM node:20-alpine@sha256:c13b26e7e602ef2f1074aef304ce6e9b7dd284c419b35d89fcf3cc8e44a8def9 AS production-stage
 COPY --link --from=build-stage /app/.output /app
 WORKDIR /app
 ENV NITRO_PORT=80


### PR DESCRIPTION
i just spent more than 2h figuring out why building our docker containers doesn't work anymore. turns out the node:lts-alpine changed to node version 22 instead of 20 today in the morning. And with node version 22, apparently our builds don't work, `npm ci` doesn't ever finish