### PR TITLE
SC-190: fix infobox bug

### DIFF
--- a/frontend/components/Infobox.vue
+++ b/frontend/components/Infobox.vue
@@ -66,12 +66,12 @@ onUnmounted(() => {
 });
 
 function clearTimer() {
-  if (!timeoutId.value) return;
+  if (timeoutId.value == undefined) return;
   clearTimeout(timeoutId.value);
 }
 
 function restartTimer() {
-  if (!props.withTimeout) return;
+  if (!props.withTimeout || !infoboxIsOpen.value) return;
   clearTimer();
   timeoutId.value = setTimeout(() => {
     toggleInfobox();


### PR DESCRIPTION
This bug was caused by the transition of the infobox. The mouseover was called during the closing transition after clicking on the close button. This led the infobox to reapper seemingly randomly 10 seconds later.