### PR TITLE
SEO hotfix: use caching instead of prerendering

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -10,20 +10,26 @@ export default defineNuxtConfig({
     "nuxt-laravel-echo",
     "@nuxtjs/seo",
   ],
-  nitro: {
-    prerender: {
-      routes: [
-        "/",
-        "/de",
-        "/legal-notice",
-        "/de/impressum",
-        "/role",
-        "/de/rolle",
-      ],
-    },
-  },
   routeRules: {
     // https://github.com/nuxt-modules/i18n/issues/2342 // there doesn't seem to be a clean way to define route rules than this ... f*ck localized slugs
+    "/": {
+      swr: true,
+    },
+    "/de": {
+      swr: true,
+    },
+    "/legal-notice": {
+      swr: true,
+    },
+    "/de/impressum": {
+      swr: true,
+    },
+    "/role": {
+      swr: true,
+    },
+    "/de/rolle": {
+      swr: true,
+    },
     "/**": {
       seoMeta: {
         ogImage: "/og-image-en.png",

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -11,7 +11,7 @@ export default defineNuxtConfig({
     "@nuxtjs/seo",
   ],
   routeRules: {
-    // https://github.com/nuxt-modules/i18n/issues/2342 // there doesn't seem to be a clean way to define route rules than this ... f*ck localized slugs
+    // https://github.com/nuxt-modules/i18n/issues/2342 // there doesn't seem to be a cleaner way to define route rules than like this ... f*ck localized slugs
     "/": {
       swr: true,
     },


### PR DESCRIPTION
Prerendering isn't possible, as we want others to be able to use the same containers, and env vars such as backend/reverb url aren't known to us during build time, because they will be different to every user. *We* could prerender just fine, we know everything at build time, but then the website wouldn't work for docker container users.